### PR TITLE
 Dani/feature/prop types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^5.3.0",

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -71,9 +71,6 @@ class App extends React.Component {
             const foundMovie = this.state.movies.find(
               (item) => `${item.id}` === match.params.id
             );
-            console.log("MATCH PARAMS MOVIE", match);
-            console.log("STATE", this.state.movies);
-            console.log("FOUND MOVIE", foundMovie);
             return <MovieDetails selectedMovie={foundMovie} />;
           }}
         />

--- a/src/components/Banner/Banner.css
+++ b/src/components/Banner/Banner.css
@@ -1,3 +1,5 @@
 .banner {
   width: 100vw;
+  height: 60vh;
+  object-fit: cover;
 }

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -1,11 +1,12 @@
 import React from "react";
 import "./Banner.css";
+import PropTypes from "prop-types";
 
 class Banner extends React.Component {
-  constructor(props) {
-    super(props);
+  constructor({ movies }) {
+    super();
     this.state = {
-      banner: props.movies[Math.floor(Math.random() * props.movies.length)]
+      banner: movies[Math.floor(Math.random() * movies.length)],
     };
   }
 
@@ -13,7 +14,7 @@ class Banner extends React.Component {
     return (
       <img
         className="banner"
-        src={`${this.state.banner['backdrop_path']}`}
+        src={`${this.state.banner["backdrop_path"]}`}
         alt={`image from ${this.state.banner.title}`}
       />
     );
@@ -21,3 +22,22 @@ class Banner extends React.Component {
 }
 
 export default Banner;
+
+Banner.propTypes = {
+  movies: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+Banner.defaultProps = {
+  movies: [
+    {
+      id: 508439,
+      poster_path:
+        "https://image.tmdb.org/t/p/original//f4aul3FyD3jv3v4bul1IrkWZvzq.jpg",
+      backdrop_path:
+        "https://image.tmdb.org/t/p/original//xFxk4vnirOtUxpOEWgA1MCRfy6J.jpg",
+      title: "Onward",
+      average_rating: 6.4,
+      release_date: "2020-02-29",
+    },
+  ],
+};

--- a/src/components/Movie/Movie.jsx
+++ b/src/components/Movie/Movie.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import "./Movie.css";
+import { number, shape, string } from "prop-types";
 
 const Movie = ({ singleMovie }) => {
   return (
@@ -13,3 +14,14 @@ const Movie = ({ singleMovie }) => {
 };
 
 export default Movie;
+
+Movie.propTypes = {
+  singleMovie: shape({
+    id: number.isRequired,
+    poster_path: string.isRequired,
+    backdrop_path: string.isRequired,
+    title: string.isRequired,
+    average_rating: number.isRequired,
+    release_date: string.isRequired,
+  }).isRequired,
+};

--- a/src/components/MovieDetails/MovieDetails.css
+++ b/src/components/MovieDetails/MovieDetails.css
@@ -24,6 +24,7 @@
   background-color: #000000;
   width: 70vh;
   height: 90vh;
+  box-shadow: 1px 1px 10px 5px rgba(255, 255, 255, 0.423);
 }
 
 .movieDetailsBtnContainer {
@@ -56,6 +57,7 @@
 }
 
 .movieDetailsTitle {
+  font-weight: 900;
   display: flex;
   color: rgb(247, 82, 82);
 }

--- a/src/components/MovieDetails/MovieDetails.jsx
+++ b/src/components/MovieDetails/MovieDetails.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import "./MovieDetails.css";
 import { Link } from "react-router-dom";
+import { number, shape, string } from "prop-types";
 
 const MovieDetails = ({ selectedMovie }) => {
   return (
@@ -37,3 +38,14 @@ const MovieDetails = ({ selectedMovie }) => {
 };
 
 export default MovieDetails;
+
+MovieDetails.propTypes = {
+  selectedMovie: shape({
+    id: number.isRequired,
+    poster_path: string.isRequired,
+    backdrop_path: string.isRequired,
+    title: string.isRequired,
+    average_rating: number.isRequired,
+    release_date: string.isRequired,
+  }).isRequired,
+};

--- a/src/components/Movies/Movies.jsx
+++ b/src/components/Movies/Movies.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Movie from "../Movie/Movie";
 import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
 
 const Movies = ({ movies }) => {
   const displayMovies = movies.map((item) => {
@@ -14,3 +15,7 @@ const Movies = ({ movies }) => {
 };
 
 export default Movies;
+
+Movies.propTypes = {
+  movies: PropTypes.arrayOf(PropTypes.object).isRequired,
+};


### PR DESCRIPTION
What does this PR do?
---
-  Using adding prop-types package to include validation at the bottom of our components 
- This allows for our props to have required types and specifications when they are passed to a component 

What (if any) features are you implementing?
---
- [x] Creating prop-types for each component 
- [x] Creating default props for the banner component like we discussed to default to a chosen object if an object does not get passed through for whatever reason 

What (if anything) did you refactor?
---
- [x] Added prop-types as a package 
- [x] Created prop-types for components 
- [x] Created additional default component for banner 
- [x] Adjusted css for the banner so it is not as big on the page  